### PR TITLE
fix:对源库的ScrollViewComponent的overScrollMode属性的值做平台判断

### DIFF
--- a/src/ImageHeaderScrollView.js
+++ b/src/ImageHeaderScrollView.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Animated, ScrollView, StyleSheet, View, Image, Dimensions } from 'react-native';
 import type { ViewProps } from 'ViewPropTypes';
-import type { FlatList, SectionList, ListView } from 'react-native';
+import type { FlatList, SectionList, ListView, Platform } from 'react-native';
 
 type ScrollViewProps = {
   onScroll?: ?Function,
@@ -283,7 +283,7 @@ class ImageHeaderScrollView extends Component<Props, State> {
           ref={ref => {
             this.scrollViewRef = ref;
           }}
-          overScrollMode="never"
+          overScrollMode= {Platform.OS==='ios' ? "never" : "always" }
           {...scrollViewProps}
           contentContainerStyle={[
             {


### PR DESCRIPTION


# Summary

因为源库的overScrollMode="never"会导致android和harmony平台上ScrollView下拉的时候没有效果 会导致一些动画效果无法显示 所有对此属性做平台判断

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I have already compared the effects/features with the Android or iOS platforms
- [ ] I added a test for the API (if applicable)
- [ ] I have updated the JS/TS (if applicable)
- [x] I updated the documentation (if applicable)
